### PR TITLE
Fix channel and mention names showing ID in slack

### DIFF
--- a/routerDiscordToSlack.js
+++ b/routerDiscordToSlack.js
@@ -31,7 +31,7 @@ client.on('message', async msg => {
   const payload = {
     username,
     channel: channelId,
-    "text": msg.content,
+    "text": msg.cleanContent,
     icon_url: msg.author.displayAvatarURL({ format: 'png' })
   }
   const url = 'https://slack.com/api/chat.postMessage'


### PR DESCRIPTION
Partially fixes https://github.com/UniversityOfHelsinkiCS/toska-silta/issues/2
Fixes:
- Stop sending garbage with names `<@435345634543>`, just send `@SaSu` or `Sasu`
- Stop sending garbage with channel names `<#2355364543>`, just send `#keskustelua_discordissa` or `keskustelua_discordissa`