### PR TITLE
Fix emojis

### DIFF
--- a/routerDiscordToSlack.js
+++ b/routerDiscordToSlack.js
@@ -26,10 +26,11 @@ client.on('message', async msg => {
   if (!channelId) return
 
   const username = msg.member.nickname || msg.author.username
+  const contentWithCleanedEmojis = msg.cleanContent.replace(/<a?(:[^:]*:)\d+>/g, '$1');
   const payload = {
     username,
     channel: channelId,
-    "text": msg.cleanContent,
+    "text": contentWithCleanedEmojis,
     icon_url: msg.author.displayAvatarURL({ format: 'png' })
   }
   const url = 'https://slack.com/api/chat.postMessage'

--- a/routerDiscordToSlack.js
+++ b/routerDiscordToSlack.js
@@ -26,7 +26,7 @@ client.on('message', async msg => {
   if (!channelId) return
 
   const username = msg.member.nickname || msg.author.username
-  const contentWithCleanedEmojis = msg.cleanContent.replace(/<a?(:[^:]*:)\d+>/g, '$1');
+  const contentWithCleanedEmojis = msg.cleanContent.replace(/<a?(:[^:]*:)\d+>/g, '$1')
   const payload = {
     username,
     channel: channelId,


### PR DESCRIPTION
Partially fixes https://github.com/UniversityOfHelsinkiCS/toska-silta/issues/2
Fixes:
- Stop sending garbage with emojis (`<:mintu:345345879837495>`), send just `:mintu:`

Also takes into account that animated gifs have `a` in front of them: `<a:fishsteer:885601242930372668>`

The regex searches for a tag `<a:name:000000>` where `a` is optional, the name can be anything but it cannot contain `:` character, and at the end before the closing tag there must be one or more numbers.
The regex uses `g` flag to replace all instances of the found pattern from the message.
The instances are replaced with a subgroup that is `:name:` captured from the searched pattern.